### PR TITLE
Inform Notification Sound extension about new notifications

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -6,6 +6,12 @@ const notifIcons = {
   "chat": browser.extension.getURL("chat-alert.png")
 }
 
+if("onShown" in browser.notifications) {
+  browser.notifications.onShown.addListener(() => {
+    browser.runtime.sendMessage("@notification-sound", "new-notification");
+  });
+}
+
 browser.runtime.onMessage.addListener(notif => {
   console.log("received onMessage on background script: ", notif);
   browser.notifications.create({


### PR DESCRIPTION
Makes the Notification Sound extension play a sound when this extension shows a notification in Firefox 56 and later.